### PR TITLE
Adding git support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --update \
       python \
       python-dev \
       py-pip \
+      git \
       g++ && \
       pip install cookiecutter && \
       apk del g++ py-pip  python-dev && \


### PR DESCRIPTION
Since cookiecutter supports git, it's a good idea to install the git binnary on this docker image.